### PR TITLE
[#13] Feat: Eureka-microservice-loadbalancing

### DIFF
--- a/employee-service/src/main/java/github/Jimoou/employeeservice/Service/APIClient.java
+++ b/employee-service/src/main/java/github/Jimoou/employeeservice/Service/APIClient.java
@@ -5,7 +5,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(url = "http://localhost:8080", value = "DEPARTMENT-SERVICE")
+@FeignClient(name = "DEPARTMENT-SERVICE")
 public interface APIClient {
   // Get 부서
   @GetMapping("api/departments/{department-code}")


### PR DESCRIPTION
1. 8761 포트에 eureka 서버 실행 Department-service와 employee-service에 eureka-client 의존성을 추가하고, application.properties 설정을 통해
두 서비스를 eureka 서버에 등록
2. netflix-eureka-server-client 의존성이 내장하고 있는 로드밸런서 기능을 사용하기 위해 @FeignClient의 url과 value를 삭제하고, 서비스 이름을 매핑시켜 주었다.