### PR TITLE
[#18] Feat: SpringCloud-Config-Server

### DIFF
--- a/config-server/.gitignore
+++ b/config-server/.gitignore
@@ -1,0 +1,38 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+/src/main/resources/application.properties

--- a/config-server/build.gradle
+++ b/config-server/build.gradle
@@ -1,0 +1,35 @@
+plugins {
+	id 'java'
+	id 'org.springframework.boot' version '3.0.5'
+	id 'io.spring.dependency-management' version '1.1.0'
+}
+
+group = 'github.Jimoou'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '17'
+
+repositories {
+	mavenCentral()
+	maven { url 'https://artifactory-oss.prod.netflix.net/artifactory/maven-oss-candidates' }
+}
+
+ext {
+	set('springCloudVersion', "2022.0.2")
+}
+
+dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.cloud:spring-cloud-config-server'
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
+}
+
+tasks.named('test') {
+	useJUnitPlatform()
+}

--- a/config-server/src/main/java/github/Jimoou/configserver/ConfigServerApplication.java
+++ b/config-server/src/main/java/github/Jimoou/configserver/ConfigServerApplication.java
@@ -1,0 +1,14 @@
+package github.Jimoou.configserver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.config.server.EnableConfigServer;
+
+@SpringBootApplication
+@EnableConfigServer
+public class ConfigServerApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(ConfigServerApplication.class, args);
+  }
+}

--- a/config-server/src/test/java/github/Jimoou/configserver/ConfigServerApplicationTests.java
+++ b/config-server/src/test/java/github/Jimoou/configserver/ConfigServerApplicationTests.java
@@ -1,0 +1,13 @@
+package github.Jimoou.configserver;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ConfigServerApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/department-service/build.gradle
+++ b/department-service/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     implementation 'org.modelmapper:modelmapper:3.1.1'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.cloud:spring-cloud-starter-config'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/department-service/src/main/resources/application.properties
+++ b/department-service/src/main/resources/application.properties
@@ -1,1 +1,14 @@
+## These settings are moved to Config server repo.
+#spring.datasource.url=jdbc:mysql://localhost:<port>/<database>
+#spring.datasource.username=<username>
+#spring.datasource.password=<password>
 
+#spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+#spring.jpa.hibernate.ddl-auto=update
+
+#server.port=8082
+
+spring.application.name=DEPARTMENT-SERVICE
+spring.config.import=optional:configserver:http://localhost:8888
+management.endpoints.web.exposure.include=*
+#eureka.client.service-url.defaultZone=http://localhost:8761/eureka/

--- a/employee-service/build.gradle
+++ b/employee-service/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.cloud:spring-cloud-starter-config'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/employee-service/src/main/resources/application.properties
+++ b/employee-service/src/main/resources/application.properties
@@ -1,1 +1,14 @@
+## These settings are moved to Config server repo.
+#spring.datasource.url=jdbc:mysql://localhost:<port>/<database>
+#spring.datasource.username=<username>
+#spring.datasource.password=<password>
 
+#spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+#spring.jpa.hibernate.ddl-auto=update
+
+#server.port=8081
+
+spring.application.name=EMPLOYEE-SERVICE
+spring.config.import=optional:configserver:http://localhost:8888
+management.endpoints.web.exposure.include=*
+#eureka.client.service-url.defaultZone=http://localhost:8761/eureka/


### PR DESCRIPTION
1. Module 생성 `Spring Boot Actuator`
`Config Server`
`Eureak Client`

2. config-server-repo 생성 마이크로 서비스의 각 설정 파일을 외부화 하기 위해
깃허브 레포지토리에 config-server-repo를 생성해 설정파일을 커밋하였으며, 해당 레포지토리는 private으로 설정함.

config-server의 properties에 설정을 통해 config-server-repo에 있는 설정파일을 자동으로 읽어옴.

3. Refactoring `department-service`
`employee-service`
모두 속성 파일을 외부화하고 기존 속성은 참고용으로 주석처리만 해놓음.
`spring boot actuator` 의존성을 추가해, config-server의 업데이트 내용을 새로 시작 없이 받아올 수 있게 설정함.

`config client` 의존성을 추가해 config-server와 설정을 매핑했음.