### PR TITLE
Feature/#22 resilence4j circuit breaker pattern

### DIFF
--- a/department-service/src/main/resources/application.properties
+++ b/department-service/src/main/resources/application.properties
@@ -10,8 +10,8 @@
 
 spring.rabbitmq.host=localhost
 spring.rabbitmq.port=5672
-spring.rabbitmq.username=quest
-spring.rabbitmq.password=quest
+spring.rabbitmq.username=guest
+spring.rabbitmq.password=guest
 
 spring.application.name=DEPARTMENT-SERVICE
 spring.config.import=optional:configserver:http://localhost:8888

--- a/employee-service/build.gradle
+++ b/employee-service/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.cloud:spring-cloud-starter-bus-amqp'
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/employee-service/src/main/java/github/Jimoou/employeeservice/Service/implement/EmployeeServiceImpl.java
+++ b/employee-service/src/main/java/github/Jimoou/employeeservice/Service/implement/EmployeeServiceImpl.java
@@ -8,7 +8,7 @@ import github.Jimoou.employeeservice.Exception.ResourceNotFoundException;
 import github.Jimoou.employeeservice.Repository.EmployeeRepository;
 import github.Jimoou.employeeservice.Service.APIClient;
 import github.Jimoou.employeeservice.Service.EmployeeService;
-import lombok.AllArgsConstructor;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;import lombok.AllArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
@@ -30,6 +30,7 @@ public class EmployeeServiceImpl implements EmployeeService {
     return savedEmployeeDto;
   }
 
+  @CircuitBreaker(name = "${spring.application.name}", fallbackMethod = "getDefaultDepartment")
   @Override
   public APIResponseDto getEmployeeById(Long employeeId) {
     Employee employee =
@@ -38,6 +39,25 @@ public class EmployeeServiceImpl implements EmployeeService {
             .orElseThrow(() -> new ResourceNotFoundException("Employee", "id", employeeId));
 
     DepartmentDto departmentDto = apiClient.getDepartment(employee.getDepartmentCode());
+
+    EmployeeDto employeeDto = modelMapper.map(employee, EmployeeDto.class);
+    APIResponseDto apiResponseDto = new APIResponseDto(employeeDto, departmentDto);
+
+    return apiResponseDto;
+  }
+
+  /*fallbackMethod*/
+  public APIResponseDto getDefaultDepartment(Long employeeId, Exception e) {
+    Employee employee =
+     employeeRepository
+      .findById(employeeId)
+      .orElseThrow(() -> new ResourceNotFoundException("Employee", "id", employeeId));
+
+    /*default Department return*/
+    DepartmentDto departmentDto = new DepartmentDto();
+    departmentDto.setDepartmentCode("RD001");
+    departmentDto.setDepartmentName("R&D Department");
+    departmentDto.setDepartmentDescription("Research and Development Department");
 
     EmployeeDto employeeDto = modelMapper.map(employee, EmployeeDto.class);
     APIResponseDto apiResponseDto = new APIResponseDto(employeeDto, departmentDto);

--- a/employee-service/src/main/resources/application.properties
+++ b/employee-service/src/main/resources/application.properties
@@ -10,10 +10,25 @@
 
 spring.rabbitmq.host=localhost
 spring.rabbitmq.port=5672
-spring.rabbitmq.username=quest
-spring.rabbitmq.password=quest
+spring.rabbitmq.username=guest
+spring.rabbitmq.password=guest
 
 spring.application.name=EMPLOYEE-SERVICE
 spring.config.import=optional:configserver:http://localhost:8888
-management.endpoints.web.exposure.include=*
+
 #eureka.client.service-url.defaultZone=http://localhost:8761/eureka/
+
+## Actuator endpoints for Circuit Breaker
+management.health.circuitbreakers.enabled=true
+management.endpoints.web.exposure.include=health
+management.endpoint.health.show-details=always
+
+## Circuit Breaker configuration
+resilience4j.circuitbreaker.instances.EMPLOYEE-SERVICE.register-health-indicator=true
+resilience4j.circuitbreaker.instances.EMPLOYEE-SERVICE.failure-rate-threshold=50
+resilience4j.circuitbreaker.instances.EMPLOYEE-SERVICE.minimum-number-of-calls=5
+resilience4j.circuitbreaker.instances.EMPLOYEE-SERVICE.automatic-transition-from-open-to-half-open-enabled=true
+resilience4j.circuitbreaker.instances.EMPLOYEE-SERVICE.wait-duration-in-open-state=5s
+resilience4j.circuitbreaker.instances.EMPLOYEE-SERVICE.permitted-number-of-calls-in-half-open-state=3
+resilience4j.circuitbreaker.instances.EMPLOYEE-SERVICE.sliding-window-size=10
+resilience4j.circuitbreaker.instances.EMPLOYEE-SERVICE.sliding-window-type=count_based


### PR DESCRIPTION
#Resilience4j를 사용한 회로 차단기 패턴 구현

1. **무한 재시도 문제 해결**: 재시도 패턴은 서비스가 복구되기 전까지 무한히 재시도할 수 있습니다. 이로 인해 시스템이 불안정해질 수 있습니다. 반면 회로 차단기 패턴은 일정 시간 후에만 시도를 해보며, 시스템의 안정성을 유지하는 데 도움이 됩니다.

2. **실패한 서비스에 대한 응답 속도 개선**: 재시도 패턴은 실패한 서비스에 대해 여러 번 시도하기 때문에 응답 시간이 길어질 수 있습니다. 회로 차단기 패턴은 일정한 실패율에 도달하면 서비스 호출을 차단하므로, 응답 속도가 개선됩니다.

3. **리소스 사용 최적화**: 회로 차단기 패턴은 실패한 서비스 호출을 줄여 리소스 사용량을 최적화합니다. 이는 시스템의 전체적인 효율성을 높입니다.

변경사항
`application.properties`: 회로 차단기 관련 설정 추가
`EmployeeServiceImpl`: @CircuitBreaker 어노테이션 및 회로 차단기가 동작할 때 사용할 대체 메서드 추가
`build.gradle`: Resilience4j와 관련된 의존성 추가

회로차단 설정
- `register-health-indicator`: 회로 차단기의 건강 상태를 Actuator 엔드포인트에 등록하도록 설정합니다.
- `failure-rate-threshold`: 회로 차단기를 열어서 호출을 차단하는데 필요한 실패율 임계값을 설정합니다 (0~100 사이의 백분율). 이 경우에는 50%로 설정되어 있습니다.
- `minimum-number-of-calls`: 임계값을 계산하기 전에 처리해야 하는 최소 호출 횟수를 설정합니다. 이 경우에는 최소 5회 호출이 필요합니다.(기본값은 100회, 테스트를 위해 5회로 설정)
- `automatic-transition-from-open-to-half-open-enabled`: 회로 차단기가 자동으로 OPEN 상태에서 HALF-OPEN 상태로 전환하는지 여부를 설정합니다. 이 경우에는 자동 전환을 활성화합니다.
- `wait-duration-in-open-state`: 회로 차단기가 OPEN 상태에서 HALF-OPEN 상태로 전환하기 전에 대기해야 하는 시간을 설정합니다. 이 경우에는 5초로 설정되어 있습니다.
- `permitted-number-of-calls-in-half-open-state`: HALF-OPEN 상태에서 허용되는 호출 횟수를 설정합니다. 이 경우에는 3회로 설정되어 있습니다.
- `sliding-window-size`: 회로 차단기의 슬라이딩 윈도우 크기를 설정합니다. 이 경우에는 10으로 설정되어 있습니다. 
- `sliding-window-type`: 회로 차단기의 슬라이딩 윈도우 유형을 설정합니다. 이 경우에는 count_based로 설정되어 있습니다. 슬라이딩 윈도우 유형은 time_based와 count_based 중 선택할 수 있습니다. count_based는 윈도우가 최근 N개의 호출을 기반으로 계산하며, time_based는 설정된 시간 범위 내에서 호출을 기반으로 계산합니다.